### PR TITLE
Added option to disable warping from last to first desktop.

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -2,6 +2,7 @@
 DefaultDesktop=1
 TaskbarScrollSwitching=1
 UseNativePrevNextDesktopSwitchingIfConflicting=0
+WarpFromEndToStart=1
 
 [Tooltips]
 Enabled=1

--- a/virtual-desktop-enhancer.ahk
+++ b/virtual-desktop-enhancer.ahk
@@ -56,6 +56,7 @@ Menu, Tray, Click, 1
 
 ReadIni("settings.ini")
 
+global WarpFromEndToStart := (GeneralWarpFromEndToStart != "" and GeneralWarpFromEndToStart ~= "^[01]$") ? GeneralWarpFromEndToStart : 1
 global TooltipsEnabled := (TooltipsEnabled != "" and TooltipsEnabled ~= "^[01]$") ? TooltipsEnabled : 1
 global TooltipsLifespan := (TooltipsLifespan != "" and TooltipsLifespan ~= "^\d+$") ? TooltipsLifespan : 750
 global TooltipsCentered := (TooltipsCentered != "" and TooltipsCentered ~= "^[01]$") ? TooltipsCentered : 1
@@ -396,13 +397,23 @@ _GetDesktopName(n:=1) {
 
 _GetNextDesktopNumber() {
     i := _GetCurrentDesktopNumber()
-    i := (i = _GetNumberOfDesktops() ? 1 : i + 1)
+	if (WarpFromEndToStart == 1) {
+		i := (i == _GetNumberOfDesktops() ? 1 : i + 1)
+	} else {
+		i := (i == _GetNumberOfDesktops() ? i : i + 1)
+	}
+	
     return i
 }
 
 _GetPreviousDesktopNumber() {
     i := _GetCurrentDesktopNumber()
-    i := (i = 1 ? _GetNumberOfDesktops() : i - 1)
+	if (WarpFromEndToStart == 1) {
+		i := (i == 1 ? _GetNumberOfDesktops() : i - 1)
+	} else {
+		i := (i == 1 ? i : i - 1)
+	}
+    
     return i
 }
 


### PR DESCRIPTION
I added an option which lets a user choose whether to warp from last dekstop to the first one and vice versa or to keep the default behaviour (cannot go left form the first one and cannot go right from the first one).

resolve #36 