### PR TITLE
Edited the 'tooltip' library to support multi-monitor setups and more tooltip customization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,27 +95,32 @@ You can customize the appearance of this tooltip:
 | Setting         | Description                                                                               | Valid Values                                   |
 | --------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | Enabled         | If tooltips should be shown.                                                              | 1 (Yes), 0 (No).                               |
-| Centered        | If the tooltips should appear at the center of the screen, or in the bottom right corner. | 1 (center), 0 (corner).                        |
+| PositionX       | The horizontal position of the tooltip on the monitor.                                    | LEFT, CENTER, RIGHT.                           |
+| PositionY       | The vertical position of the tooltip on the monitor.                                      | TOP, CENTER, BOTTOM.                           |
 | FontSize        | The size of the font.                                                                     | Any reasonable number.                         |
 | FontColor       | The color of the font.                                                                    | Any hexadecimal number (from 0x0 to 0xFFFFFF). |
 | FontInBold      | If the font should be in bold.                                                            | 1 (Yes), 0 (No).                               |
 | BackgroundColor | The color of the background.                                                              | Any hexadecimal number (from 0x0 to 0xFFFFFF). |
 | Lifespan        | The time in milliseconds for which each tooltip will be displayed.                        | Any reasonable number.                         |
+| OnEveryMonitor  | If the tolltips should be shown on every monitor or just on the primary one.              | 1 (Yes), 0 (No).                               |
 
 As an example, you have the default configuration:
 
 <pre>
 [Tooltips]
 Enabled=1
-Centered=1
+PositionX=CENTER
+PositionY=CENTER
 FontSize=11
 FontColor=0xFFFFFF
 FontInBold=1
 BackgroundColor=0x1F1F1F
 Lifespan=750
+FadeOutAnimationDuration=100
+OnEveryMonitor=1
 </pre>
 
-It draws tooltips at the center of the screen, in a white, bold and small font, with a dark background, and they are displayed for 750 milliseconds.
+It draws tooltips at the center of the screen, in a white, bold and small font, with a dark background, and they are displayed on every monitor for 750 milliseconds, with a fade out animation during 100 miliseconds.
 
 ### Keyboard Shortcuts
 

--- a/libraries/tooltip.ahk
+++ b/libraries/tooltip.ahk
@@ -17,8 +17,13 @@ Toast(params:=0) {
 
 	DetectHiddenWindows, On
 
-	; Get total number of monitors.
-	SysGet, monitorN, 80
+  if (TooltipsOnEveryMonitor == "1") {
+    ; Get total number of monitors.
+    SysGet, monitorN, 80
+  } else {
+    ; Consider just the primary monitor.
+    monitorN = 1
+  }
 
 	; For each monitor we need to create and draw the GUI of the toast.
 	Loop, %monitorN% {

--- a/libraries/tooltip.ahk
+++ b/libraries/tooltip.ahk
@@ -45,15 +45,22 @@ Toast(params:=0) {
 		WinGetPos, GUIX, GUIY, GUIWidth, GUIHeight
 		GUIWidth += 20
 		GUIHeight += 15
-		if (position == 0) {
-			; Lower right angle
-			NewX := WorkSpaceRight - GUIWidth
-			NewY := WorkspaceBottom - GUIHeight - 12
-		} else {
-			; Center
-			NewX := (WorkSpaceRight + WorkspaceLeft - GUIWidth) / 2
-			NewY := (WorkspaceBottom + WorkSpaceTop - GUIHeight) / 2
-		}
+    if (ToolTipsPositionX == "LEFT") {
+      NewX := WorkSpaceLeft
+    } else if (ToolTipsPositionX == "RIGHT") {
+      NewX := WorkSpaceRight - GUIWidth
+    } else {
+      ; CENTER or something wrong.
+      NewX := (WorkSpaceRight + WorkspaceLeft - GUIWidth) / 2
+    }
+    if (ToolTipsPositionY == "TOP") {
+      NewY := WorkSpaceTop
+    } else if (ToolTipsPositionY == "BOTTOM") {
+      NewY := WorkSpaceBottom - GUIHeight
+    } else {
+      ; CENTER or something wrong.
+      NewY := (WorkSpaceTop + WorkspaceBottom - GUIHeight) / 2
+    }
 
 		; Show the GUI
 		Gui, %GUIHandleName%:Show, Hide x%NewX% y%NewY% w%GUIWidth% h%GUIHeight%
@@ -76,7 +83,7 @@ closePopups() {
 	Loop, %monitorN% {
 		GUIHandleName = GUIForMonitor%A_Index%
 		; Fade out each toast window.
-		DllCall("AnimateWindow", "UInt", GUI_ID_%A_Index%, "Int", 150, "UInt", "0x00090000")
+		DllCall("AnimateWindow", "UInt", GUI_ID_%A_Index%, "Int", TooltipsFadeOutAnimationDuration, "UInt", "0x00090000")
 		; Free the memory used by each toast.
 		Gui, %GUIHandleName%:Destroy
 	}

--- a/libraries/tooltip.ahk
+++ b/libraries/tooltip.ahk
@@ -1,59 +1,83 @@
 ﻿; Credits to engunneer (http://www.autohotkey.com/board/topic/21510-toaster-popups/#entry140824)
 
+; Disaply a toast popup on each monitor.
 Toast(params:=0) {
+	; We need this so that all the GUI_ID_X variables are global.
+	global
+
+	local message, lifespan, position, fontSize, fontWeight, fontColor, backgroundColor, GUIHandleName, GUIX, GUIY, GUIWidth, GUIHeight, NewX, NewY
 
 	message := params.message ? params.message : ""
 	lifespan := params.lifespan ? params.lifespan : 1500
 	position := params.position ? params.position : 0
-	doWait := params.doWait ? params.doWait : 0
 	fontSize := params.fontSize ? params.fontSize : 11
 	fontWeight := params.fontWeight ? params.fontWeight : 700
 	fontColor := params.fontColor ? params.fontColor : "0xFFFFFF"
 	backgroundColor := params.backgroundColor ? params.backgroundColor : "0x1F1F1F"
 
-	Global TP_GUI_ID 
 	DetectHiddenWindows, On
-	SysGet, Workspace, MonitorWorkArea
-	Gui, 89:Destroy
-	Gui, 89:-Caption +ToolWindow +LastFound +AlwaysOnTop
-	Gui, 89:Color, %backgroundColor%
-	Gui, 89:Font, s%fontSize% c%fontColor% w%fontWeight%, Segoe UI
-	Gui, 89:Add, Text, xp+25 yp+20 gTP_Fade, %message%
-	Gui, 89:Show, Hide
-	TP_GUI_ID := WinExist()
-	WinGetPos, GUIX, GUIY, GUIWidth, GUIHeight, ahk_id %TP_GUI_ID%
-	
-	GUIWidth += 20
-	GUIHeight += 15
 
-	if (position==0) {
-		NewX := WorkSpaceRight-GUIWidth
-		NewY := WorkspaceBottom-GUIHeight-12
-	}
-	else {
-		NewX := (WorkSpaceRight-GUIWidth)/2
-		NewY := (WorkspaceBottom-GUIHeight)/2
-	}
+	; Get total number of monitors.
+	SysGet, monitorN, 80
 
-	Gui, 89:Show, Hide x%NewX% y%NewY% w%GUIWidth% h%GUIHeight%
+	; For each monitor we need to create and draw the GUI of the toast.
+	Loop, %monitorN% {
+		; We need a different handle for each GUI in each monitor.
+		GUIHandleName = GUIForMonitor%A_Index%
 
-	DllCall("AnimateWindow","UInt",TP_GUI_ID,"Int",1,"UInt","0x00080000") ; TOAST!
-	if (lifespan) {
-		SetTimer, TP_Fade, % lifespan
-		if(doWait == 1) {
-			Sleep % lifespan
+		; Get the workspace of the monitor.
+		SysGet, Workspace, MonitorWorkArea, %A_Index%
+
+		; Greate the GUI.
+		Gui, %GUIHandleName%:Destroy
+		Gui, %GUIHandleName%:-Caption +ToolWindow +LastFound +AlwaysOnTop
+		Gui, %GUIHandleName%:Color, %backgroundColor%
+		Gui, %GUIHandleName%:Font, s%fontSize% c%fontColor% w%fontWeight%, Segoe UI
+		Gui, %GUIHandleName%:Add, Text, xp+25 yp+20, %message%
+		Gui, %GUIHandleName%:Show, Hide
+
+		OnMessage(0x201, "closePopups")
+
+		; Save the GUI ID of each GUI in a different variable.
+		GUI_ID_%A_Index% := WinExist()
+
+		; Position the GUI on the monitor.
+		WinGetPos, GUIX, GUIY, GUIWidth, GUIHeight
+		GUIWidth += 20
+		GUIHeight += 15
+		if (position == 0) {
+			; Lower right angle
+			NewX := WorkSpaceRight - GUIWidth
+			NewY := WorkspaceBottom - GUIHeight - 12
+		} else {
+			; Center
+			NewX := (WorkSpaceRight + WorkspaceLeft - GUIWidth) / 2
+			NewY := (WorkspaceBottom + WorkSpaceTop - GUIHeight) / 2
 		}
+
+		; Show the GUI
+		Gui, %GUIHandleName%:Show, Hide x%NewX% y%NewY% w%GUIWidth% h%GUIHeight%
+		DllCall("AnimateWindow", "UInt", GUI_ID_%A_Index%, "Int", 1, "UInt", "0x00080000")
 	}
+
+	; Make all the toasts from all the monitors automatically disappear after a certain time.
+	if (lifespan) {
+		; Execute closePopups() only one time after lifespan milliseconds.
+		SetTimer, closePopups, % -lifespan
+	}
+
 	Return
 }
 
-TP_Wait() {
-	Global TP_GUI_ID
-	WinWaitClose, ahk_id %TP_GUI_ID%
-}
-
-TP_Fade() {
-	DllCall("AnimateWindow","UInt",TP_GUI_ID,"Int",100,"UInt","0x00090000") ; Fade out when clicked
-	Gui, 89:Destroy
-	Return
+; Close all the toast messages.
+; This function is called after a given time (lifespan) or when the text in the toasts is clicked.
+closePopups() {
+	global
+	Loop, %monitorN% {
+		GUIHandleName = GUIForMonitor%A_Index%
+		; Fade out each toast window.
+		DllCall("AnimateWindow", "UInt", GUI_ID_%A_Index%, "Int", 150, "UInt", "0x00090000")
+		; Free the memory used by each toast.
+		Gui, %GUIHandleName%:Destroy
+	}
 }

--- a/settings.ini
+++ b/settings.ini
@@ -6,12 +6,17 @@ DesktopWrapping=1
 
 [Tooltips]
 Enabled=1
-Centered=1
+; One of LEFT, CENTER, RIGHT
+PositionX=CENTER
+; One of TOP, CENTER, BOTTOM
+PositionY=CENTER
 FontSize=11
 FontColor=0xFFFFFF
 FontInBold=1
 BackgroundColor=0x1F1F1F
 Lifespan=750
+; Watch out! Long durations (> 500ms) could cause troubles as the program freezes during the animation.
+FadeOutAnimationDuration=100
 
 [KeyboardShortcutsCombinations]
 TogglePinWindow=Win, Ctrl, Shift, Q

--- a/settings.ini
+++ b/settings.ini
@@ -17,6 +17,7 @@ BackgroundColor=0x1F1F1F
 Lifespan=750
 ; Watch out! Long durations (> 500ms) could cause troubles as the program freezes during the animation.
 FadeOutAnimationDuration=100
+OnEveryMonitor=1
 
 [KeyboardShortcutsCombinations]
 TogglePinWindow=Win, Ctrl, Shift, Q

--- a/virtual-desktop-enhancer.ahk
+++ b/virtual-desktop-enhancer.ahk
@@ -62,6 +62,7 @@ global TooltipsLifespan := (TooltipsLifespan != "" and TooltipsLifespan ~= "^\d+
 global TooltipsFadeOutAnimationDuration := (TooltipsFadeOutAnimationDuration != "" and TooltipsFadeOutAnimationDuration ~= "^\d+$") ? TooltipsFadeOutAnimationDuration : 100
 global TooltipsPositionX := (TooltipsPositionX == "LEFT" or TooltipsPositionX == "CENTER" or TooltipsPositionX == "RIGHT") ? TooltipsPositionX : "CENTER"
 global TooltipsPositionY := (TooltipsPositionY == "TOP" or TooltipsPositionY == "CENTER" or TooltipsPositionY == "BOTTOM") ? TooltipsPositionY : "CENTER"
+global TooltipsOnEveryMonitor := (TooltipsOnEveryMonitor != "" and TooltipsOnEveryMonitor ~= "^[01]$") ? TooltipsOnEveryMonitor : 1
 global TooltipsFontSize := (TooltipsFontSize != "" and TooltipsFontSize ~= "^\d+$") ? TooltipsFontSize : 11
 global TooltipsFontInBold := (TooltipsFontInBold != "" and TooltipsFontInBold ~= "^[01]$") ? (TooltipsFontInBold ? 700 : 400) : 700
 global TooltipsFontColor := (TooltipsFontColor != "" and TooltipsFontColor ~= "^0x[0-9A-Fa-f]{1,6}$") ? TooltipsFontColor : "0xFFFFFF"

--- a/virtual-desktop-enhancer.ahk
+++ b/virtual-desktop-enhancer.ahk
@@ -17,7 +17,7 @@ DetectHiddenWindows, On
 hwnd := WinExist("ahk_pid " . DllCall("GetCurrentProcessId","Uint"))
 hwnd += 0x1000 << 32
 
-hVirtualDesktopAccessor := DllCall("LoadLibrary", "Str", A_ScriptDir . "\libraries\virtual-desktop-accessor.dll", "Ptr") 
+hVirtualDesktopAccessor := DllCall("LoadLibrary", "Str", A_ScriptDir . "\libraries\virtual-desktop-accessor.dll", "Ptr")
 
 global GoToDesktopNumberProc := DllCall("GetProcAddress", Ptr, hVirtualDesktopAccessor, AStr, "GoToDesktopNumber", "Ptr")
 global RegisterPostMessageHookProc := DllCall("GetProcAddress", Ptr, hVirtualDesktopAccessor, AStr, "RegisterPostMessageHook", "Ptr")
@@ -59,7 +59,9 @@ ReadIni("settings.ini")
 global GeneralDesktopWrapping := (GeneralDesktopWrapping != "" and GeneralDesktopWrapping ~= "^[01]$") ? GeneralDesktopWrapping : 1
 global TooltipsEnabled := (TooltipsEnabled != "" and TooltipsEnabled ~= "^[01]$") ? TooltipsEnabled : 1
 global TooltipsLifespan := (TooltipsLifespan != "" and TooltipsLifespan ~= "^\d+$") ? TooltipsLifespan : 750
-global TooltipsCentered := (TooltipsCentered != "" and TooltipsCentered ~= "^[01]$") ? TooltipsCentered : 1
+global TooltipsFadeOutAnimationDuration := (TooltipsFadeOutAnimationDuration != "" and TooltipsFadeOutAnimationDuration ~= "^\d+$") ? TooltipsFadeOutAnimationDuration : 100
+global TooltipsPositionX := (TooltipsPositionX == "LEFT" or TooltipsPositionX == "CENTER" or TooltipsPositionX == "RIGHT") ? TooltipsPositionX : "CENTER"
+global TooltipsPositionY := (TooltipsPositionY == "TOP" or TooltipsPositionY == "CENTER" or TooltipsPositionY == "BOTTOM") ? TooltipsPositionY : "CENTER"
 global TooltipsFontSize := (TooltipsFontSize != "" and TooltipsFontSize ~= "^\d+$") ? TooltipsFontSize : 11
 global TooltipsFontInBold := (TooltipsFontInBold != "" and TooltipsFontInBold ~= "^[01]$") ? (TooltipsFontInBold ? 700 : 400) : 700
 global TooltipsFontColor := (TooltipsFontColor != "" and TooltipsFontColor ~= "^0x[0-9A-Fa-f]{1,6}$") ? TooltipsFontColor : "0xFFFFFF"
@@ -402,7 +404,7 @@ _GetNextDesktopNumber() {
 	} else {
 		i := (i == _GetNumberOfDesktops() ? i : i + 1)
 	}
-	
+
     return i
 }
 
@@ -413,7 +415,7 @@ _GetPreviousDesktopNumber() {
 	} else {
 		i := (i == 1 ? i : i - 1)
 	}
-    
+
     return i
 }
 


### PR DESCRIPTION
Toasts can now be dismissed by clicking on them (previosly you had to click on the text inside the toast),

I tested my edits with an old TV as external monitor and from what I could see it worked OK, however it would be better if someone tested this on a real dual monitor setup to verify there are no glithches.

Solve #6