### PR TITLE
Added a function to change desktop names "On the run".

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -163,6 +163,7 @@ The following actions are not executed in the context of a virtual desktop and t
 - Unpin the currently visible app
 - Toggle pin on the currently visible window
 - Toggle pin on the currently visible app
+- Change the current desktop name
 
 For each of these actions, you can set a combination of zero or more modifiers (as before), as well as a regular key.
 For example: if you want to set up a keyboard shortcut to be able to pin the current window, you just need to set up that combination (for example, `Win, Ctrl, Q`).
@@ -228,6 +229,7 @@ _Combination_ keys' settings follow the same rules as [modifier keys' settings](
 | PinApp                       | Pin all of the windows of the currently opened app.           |
 | UnpinWindow                  | Unpin the current window.                                     |
 | UnpinApp                     | Unpin all of the windows of the currently opened app.         |
+| ChangeDesktopName            | Change the name of the current desktop with a popup prompt.   |
 
 ### Example configurations
 
@@ -257,6 +259,7 @@ UnpinWindow=
 UnpinApp=
 ; "SC029" is the key below your "Esc" key
 OpenDesktopManager=LAlt, SC029
+ChangeDesktopName=Win, F2
 ```
 
 The following shortcuts are available:

--- a/settings.ini
+++ b/settings.ini
@@ -28,6 +28,7 @@ UnpinWindow=
 UnpinApp=
 ; "SC029" is the key below your "Esc" key
 OpenDesktopManager=LAlt, SC029
+ChangeDesktopName=Win, F2
 
 [KeyboardShortcutsModifiers]
 SwitchDesktop=Win, Ctrl

--- a/virtual-desktop-enhancer.ahk
+++ b/virtual-desktop-enhancer.ahk
@@ -77,6 +77,9 @@ global previousDesktopNo=0
 global doFocusAfterNextSwitch=0
 global hasSwitchedDesktopsBefore=1
 
+global changeDesktopNamesPopupTitle := "Windows 10 Virtual Desktop Enhancer"
+global changeDesktopNamesPopupText :=  "Change the desktop name of desktop #{:d}"
+
 initialDesktopNo := _GetCurrentDesktopNumber()
 
 SwitchToDesktop(GeneralDefaultDesktop)
@@ -365,7 +368,7 @@ OpenDesktopManager() {
 ChangeDesktopName() {
     currentDesktopNumber := _GetCurrentDesktopNumber()
     currentDesktopName := _GetDesktopName(currentDesktopNumber)
-    InputBox, newDesktopName, Change desktop name, Change the desktop name of desktop #%currentDesktopNumber%, , , , , , , , %currentDesktopName%
+    InputBox, newDesktopName, % changeDesktopNamesPopupTitle, % Format(changeDesktopNamesPopupText, _GetCurrentDesktopNumber()), , , , , , , , %currentDesktopName%
     ; If the user choose "Cancel" ErrorLevel is set to 1.
     if (ErrorLevel == 0) {
         _SetDesktopName(currentDesktopNumber, newDesktopName)

--- a/virtual-desktop-enhancer.ahk
+++ b/virtual-desktop-enhancer.ahk
@@ -104,6 +104,7 @@ hkComboPinApp              := KeyboardShortcutsCombinationsPinApp
 hkComboUnpinApp            := KeyboardShortcutsCombinationsUnpinApp
 hkComboTogglePinApp        := KeyboardShortcutsCombinationsTogglePinApp
 hkComboOpenDesktopManager  := KeyboardShortcutsCombinationsOpenDesktopManager
+hkComboChangeDesktopName     := KeyboardShortcutsCombinationsChangeDesktopName
 
 arrayS := Object(),                     arrayR := Object()
 arrayS.Insert("\s*|,"),                 arrayR.Insert("")
@@ -126,6 +127,7 @@ for index in arrayS {
     hkComboUnpinApp           := RegExReplace(hkComboUnpinApp, arrayS[index], arrayR[index])
     hkComboTogglePinApp       := RegExReplace(hkComboTogglePinApp, arrayS[index], arrayR[index])
     hkComboOpenDesktopManager := RegExReplace(hkComboOpenDesktopManager, arrayS[index], arrayR[index])
+    hkComboChangeDesktopName    := RegExReplace(hkComboChangeDesktopName, arrayS[index], arrayR[index])    
 }
 
 ; Setup key bindings dynamically
@@ -191,6 +193,8 @@ setUpHotkeyWithCombo(hkComboUnpinApp, "OnUnpinAppPress", "[KeyboardShortcutsComb
 setUpHotkeyWithCombo(hkComboTogglePinApp, "OnTogglePinAppPress", "[KeyboardShortcutsCombinations] TogglePinApp")
 
 setUpHotkeyWithCombo(hkComboOpenDesktopManager, "OpenDesktopManager", "[KeyboardShortcutsCombinations] OpenDesktopManager")
+
+setUpHotkeyWithCombo(hkComboChangeDesktopName, "ChangeDesktopName", "[KeyboardShortcutsCombinations] ChangeDesktopName")
 
 if (GeneralTaskbarScrollSwitching) {
     Hotkey, ~WheelUp, OnTaskbarScrollUp
@@ -354,6 +358,20 @@ OpenDesktopManager() {
     Send #{Tab}
 }
 
+; Let the user change desktop names with a prompt, without having to edit the 'settings.ini'
+; file and reload the program.
+; The changes are temprorary (names will be overwritten by the default values of
+; 'settings.ini' when the program will be restarted.
+ChangeDesktopName() {
+    currentDesktopNumber := _GetCurrentDesktopNumber()
+    currentDesktopName := _GetDesktopName(currentDesktopNumber)
+    InputBox, newDesktopName, Change desktop name, Change the desktop name of desktop #%currentDesktopNumber%, , , , , , , , %currentDesktopName%
+    ; If the user choose "Cancel" ErrorLevel is set to 1.
+    if (ErrorLevel == 0) {
+        _SetDesktopName(currentDesktopNumber, newDesktopName)
+    }
+}
+
 Reload() {
     Reload
 }
@@ -400,6 +418,18 @@ _GetDesktopName(n:=1) {
         name := "Desktop " . n
     }
     return name
+}
+
+; Set the name of the nth desktop to the value of a given string.
+_SetDesktopName(n:=1, name:=0) {
+    if (n == 0) {
+        n := 10
+    }
+    if (!name) {
+        ; Default value: "Desktop N".
+        name := "Desktop " %n%
+    }
+    DesktopNames%n% := name
 }
 
 _GetNextDesktopNumber() {


### PR DESCRIPTION
Feature proposed by @achim-t in #60.

Added a new customizable shortcut (and updated documnetation accordingly) to show a popup which lets the user dinamically change the name of the current desktop.  
The change is not permanent and will be overwritten by the default values in 'settings.ini' when the program will be reloaded.