### PR TITLE
Bugfix: tooltip was not updated after changing a desktop name.

### DIFF
--- a/virtual-desktop-enhancer.ahk
+++ b/virtual-desktop-enhancer.ahk
@@ -375,6 +375,7 @@ ChangeDesktopName() {
     if (ErrorLevel == 0) {
         _SetDesktopName(currentDesktopNumber, newDesktopName)
     }
+    _ChangeAppearance(currentDesktopNumber)
 }
 
 Reload() {


### PR DESCRIPTION
Changing a desktop name at runtime did not trigger the function to update the tooltip of the taskbar icon.

Reported by @achim-t in #60.